### PR TITLE
REFACT: Python 3.5 safe

### DIFF
--- a/eatb/format/formatidentification.py
+++ b/eatb/format/formatidentification.py
@@ -41,13 +41,9 @@ class FormatIdentification():
         childs = [child for child in fmtres if child.tag.endswith(mime_tag)]
         if len(childs) == 1:
             return (childs[0]).text.strip()
-        else:
-            return "application/octet-stream"
+        return "application/octet-stream"
 
     def print_matches(self, fullname, matches, delta_t, matchtype=''):
         assert not fido_disabled, "Fido module is not available!"
         for (f, s) in matches:
             self.lastFmt = self.fid.get_puid(f)
-
-
-

--- a/eatb/metadata/metadata_identification.py
+++ b/eatb/metadata/metadata_identification.py
@@ -13,5 +13,5 @@ def MetaIdentification(unknown_xml):
     tag = unknown_tag.split('}')
     if len(tag) == 2:
         return tag[1]
-    elif len(tag) == 1:
+    if len(tag) == 1:
         return tag[0]

--- a/eatb/metadata/mets/ParsedMets.py
+++ b/eatb/metadata/mets/ParsedMets.py
@@ -4,10 +4,9 @@ import os
 import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))  # noqa: E402
 import lxml
-from lxml.etree import XMLSyntaxError
 
 
-class ParsedMets(object):
+class ParsedMets():
     """
     Parsed METS object
     """
@@ -56,8 +55,7 @@ class ParsedMets(object):
         file_elements = self.get_file_elements()
         if len(file_elements) > 0:
             return file_elements[0]
-        else:
-            return None
+        return None
 
     @staticmethod
     def get_file_element_checksum(file_element):
@@ -91,10 +89,6 @@ class ParsedMets(object):
             if token == ('http://www.loc.gov/METS/'):
                 position = locations.index(token)
                 schema_location = locations[position + 1]
-                if schema_location.startswith('http://'):
-                    schema_file = schema_file
-                elif schema_location.startswith(''):
+                if schema_location.startswith(''):
                     schema_file = self.root_dir + schema_location
         return schema_file
-
-

--- a/eatb/metadata/parseddcat.py
+++ b/eatb/metadata/parseddcat.py
@@ -7,7 +7,7 @@ import re
 import lxml.etree as ET
 
 
-class ParsedDcat(object):
+class ParsedDcat():
     """
     Parsed DCAT
     """
@@ -33,8 +33,7 @@ class ParsedDcat(object):
         elms = self.dcat_tree.xpath("%s%s" % (self.dataset_xpath, property), namespaces=self.ns)
         if len(elms) == 1:
             return elms[0].text
-        else:
-            raise ValueError("Invalid metadata, data set property '%s' is required." % property)
+        raise ValueError("Invalid metadata, data set property '%s' is required." % property)
 
     def get_dataset_property_values(self, properties):
         return {re.sub(r'[a-z]{1,10}:', '', prop).replace("/", "_"): self.get_dataset_property_value(prop) for prop in properties}

--- a/eatb/metadata/parsedead.py
+++ b/eatb/metadata/parsedead.py
@@ -5,7 +5,6 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))  # noqa: E402
 import re
 import lxml
-from lxml.etree import XMLSyntaxError
 
 from eatb.utils.datetime import LengthBasedDateFormat
 from eatb.utils.fileutils import get_sub_path_from_relative_path
@@ -33,7 +32,7 @@ def field_namevalue_pairs_per_file(extract_defs, ead_root_path, ead_file_path):
     return result
 
 
-class ParsedEad(object):
+class ParsedEad():
     """
     Parsed EAD object
     """
@@ -78,9 +77,8 @@ class ParsedEad(object):
         def get_text_val(node):
             if not text_accessor:
                 return node.text
-            else:
-                tc_elms = node.findall(text_accessor, namespaces=self.ns)
-                return None if len(tc_elms) != 1 else tc_elms[0].text
+            tc_elms = node.findall(text_accessor, namespaces=self.ns)
+            return None if len(tc_elms) != 1 else tc_elms[0].text
         parent_elms = current_elm.findall("..")
         if parent_elms is not None and len(parent_elms) == 1:
             parent = parent_elms[0]
@@ -88,18 +86,15 @@ class ParsedEad(object):
                 if re.match(md_tag, child.xpath('local-name()'), re.IGNORECASE):
                     if is_attr_text_accessor:
                         return child.get(text_accessor)
-                    else:
-                        return get_text_val(child)
-                else:
-                    for c in child:
-                        if re.match(md_tag, c.xpath('local-name()'), re.IGNORECASE):
-                            return get_text_val(c)
+                    return get_text_val(child)
+                for c in child:
+                    if re.match(md_tag, c.xpath('local-name()'), re.IGNORECASE):
+                        return get_text_val(c)
             if re.match(md_tag, parent.tag, re.IGNORECASE):
                 return parent.get(text_accessor)
-            else:
-                return self._first_md_val_ancpath(parent, md_tag, text_accessor, is_attr_text_accessor)
-        else:
-            return None
+            return self._first_md_val_ancpath(parent, md_tag, text_accessor,
+                                              is_attr_text_accessor)
+        return None
 
     def dao_path_mdval_tuples(self, md_tag, text_val_sub_path=None, is_attr_text_accessor=False):
         dao_elements = self.get_dao_elements()

--- a/eatb/oais/aip_creation.py
+++ b/eatb/oais/aip_creation.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import shutil
 import sys
 from lxml import etree
+
 from pathlib import Path
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))  # noqa: E402
 from eatb import root_dir
@@ -16,8 +16,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def create_aip(package_dir: str, identifier: str, package_name: str, identifier_map=None, generate_premis: bool=True,
-               generate_package: bool=True) -> bool:
+def create_aip(package_dir, identifier, package_name, identifier_map=None, generate_premis=True,
+               generate_package=True) -> bool:
 
     # schema file location for Mets generation
     schemas = os.path.join(root_dir, 'resources/schemas')
@@ -35,7 +35,7 @@ def create_aip(package_dir: str, identifier: str, package_name: str, identifier_
         metsgen.createMets(mets_data)
 
         logger.info('Generated a Mets file for representation %s.' % repdir)
-        
+
     #########
 
     # schema file location for Mets generation

--- a/eatb/oais/sip_creation.py
+++ b/eatb/oais/sip_creation.py
@@ -10,13 +10,13 @@ from eatb.metadata.premis.premisgenerator import PremisGenerator
 from eatb.packaging.package_creator import create_package
 
 import logging
-logger = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)
 
 
 def create_sip(package_dir: str, package_name: str, identifier: str, generate_premis: bool=True,
                generate_package: bool=True, custom_logger=None) -> bool:
 
-    logger = custom_logger if custom_logger else logger
+    logger = custom_logger if custom_logger else LOGGER
 
     # PREMIS
     premis_path = os.path.join(package_dir, 'metadata/preservation/premis.xml')

--- a/eatb/oais/sip_generator.py
+++ b/eatb/oais/sip_generator.py
@@ -33,7 +33,7 @@ M = objectify.ElementMaker(
     namespace=METS_NS,
     nsmap=METS_NSMAP)
 
-class SIPGenerator(object):
+class SIPGenerator():
     fid = FormatIdentification()
     mime = MimeTypes()
     root_path = ""
@@ -682,12 +682,6 @@ class SIPGenerator(object):
 
 
 class testFormatIdentification(unittest.TestCase):
-    def testCreateMetsAndPremis(self):
-        sipgen = SIPGenerator(os.path.join(root_dir, "sandbox/sipgenerator/resources/ENA_RK_TartuLV_141127"))
-        #input_folder = os.path.join(root_dir, "sandbox/sipgenerator/resources/ENA_RK_TartuLV_141127")
-        #output_mets = os.path.join(root_dir, "sandbox/sipgenerator/resources/ENA_RK_TartuLV_141127/metadata/METS.xml")
-        sipgen.createSIPMets()
-
     def atestCreateDeliveryMets(self):
         sipgen = SIPGenerator(os.path.join(root_dir, "sandbox/sipgenerator/resources/"))
         input_archive = os.path.join(root_dir, "sandbox/sipgenerator/resources/test.tar")

--- a/eatb/packaging/manifest.py
+++ b/eatb/packaging/manifest.py
@@ -9,7 +9,7 @@ from eatb.cli.cli import CliCommand
 
 
 
-class ManifestCreation(object):
+class ManifestCreation():
     """
     Create package file manifest using 'summain'
     """

--- a/eatb/packaging/package_format.py
+++ b/eatb/packaging/package_format.py
@@ -18,20 +18,18 @@ class PackageFormat:
         """
         if filename.endswith("tar.gz"):
             return PackageFormat.TARGZ
-        elif filename.endswith("tar"):
+        if filename.endswith("tar"):
             return PackageFormat.TAR
-        elif filename.endswith("zip"):
+        if filename.endswith("zip"):
             return PackageFormat.ZIP
-        else:
-            return PackageFormat.NONE
+        return PackageFormat.NONE
 
     @staticmethod
     def str(alg):
         if alg is PackageFormat.TARGZ:
             return "TARGZ"
-        elif alg is PackageFormat.TAR:
+        if alg is PackageFormat.TAR:
             return "TAR"
-        elif alg is PackageFormat.ZIP:
+        if alg is PackageFormat.ZIP:
             return "ZIP"
-        else:
-            return "NONE"
+        return "NONE"

--- a/eatb/packaging/packaged_container.py
+++ b/eatb/packaging/packaged_container.py
@@ -6,8 +6,6 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))  # noqa: E402
 import zipfile
-import os
-import sys
 
 import tarfile
 import logging
@@ -33,14 +31,13 @@ class PackagedContainer(ABC):
     def extract(self, extract_to):
         pass
 
+    @staticmethod
     def factory(filename):
         if PackageFormat.get(filename) == PackageFormat.TAR or PackageFormat.get(filename) == PackageFormat.TARGZ:
             return TarContainer(filename)
         if PackageFormat.get(filename) == PackageFormat.ZIP:
             return ZipContainer(filename)
         assert 0, "Package format not supported"
-    factory = staticmethod(factory)
-
 
 class TarContainer(PackagedContainer):
     """
@@ -150,7 +147,7 @@ class ZipContainer(PackagedContainer):
             self.stream.write('Problem to extract %s: %s\n' % (self.container_file, str(e)))
             self.success = False
         except IOError as e:
-            self.stream('Problem to extract %s: %s\n' % (self.container_file, str(e)))
+            self.stream.write('Problem to extract %s: %s\n' % (self.container_file, str(e)))
             self.success = False
         return self.success
 

--- a/eatb/packaging/tar_entry_reader.py
+++ b/eatb/packaging/tar_entry_reader.py
@@ -19,8 +19,7 @@ class ChunkedTarEntryReader(object):
     def close(self):
         if self.tfile:
             return self.tfile.close()
-        else:
-            return True
+        return True
 
     def chunks(self, entry, total_bytes_read=0, bytes_total=-1):
         """

--- a/eatb/storage/checksum.py
+++ b/eatb/storage/checksum.py
@@ -24,22 +24,20 @@ class ChecksumAlgorithm:
         """
         if alg.lower() == "md5":
             return ChecksumAlgorithm.MD5
-        elif alg.lower() == "sha256" or alg.lower() == "sha-256":
+        if alg.lower() == "sha256" or alg.lower() == "sha-256":
             return ChecksumAlgorithm.SHA256
-        else:
-            return ChecksumAlgorithm.NONE
+        return ChecksumAlgorithm.NONE
 
     @staticmethod
     def str(alg):
         if alg is ChecksumAlgorithm.MD5:
             return "MD5"
-        elif alg is ChecksumAlgorithm.SHA256:
+        if alg is ChecksumAlgorithm.SHA256:
             return "SHA256"
-        else:
-            return "NONE"
+        return "NONE"
 
 
-class ChecksumFile(object):
+class ChecksumFile():
     """
     Checksum validation
     """
@@ -60,9 +58,9 @@ class ChecksumFile(object):
         :return: Checksum string
         """
         hashval = None
-        if checksum_algorithm == ChecksumAlgorithm.SHA256 or checksum_algorithm == 'SHA-256':
+        if checksum_algorithm in [ChecksumAlgorithm.SHA256, 'SHA-256']:
             hashval = hashlib.sha256()
-        elif checksum_algorithm == ChecksumAlgorithm.MD5 or checksum_algorithm == 'MD5':
+        elif checksum_algorithm in [ChecksumAlgorithm.MD5, 'MD5']:
             hashval = hashlib.md5()
 
         with open(self.file_path, 'rb') as f:
@@ -74,7 +72,7 @@ class ChecksumFile(object):
         return hashval.hexdigest()
 
 
-class ChecksumValidation(object):
+class ChecksumValidation():
     """
     Checksum validation
     """

--- a/eatb/storage/directorypairtreestorage.py
+++ b/eatb/storage/directorypairtreestorage.py
@@ -13,7 +13,7 @@ from pairtree import PairtreeStorageFactory, ObjectNotFoundException
 from eatb.packaging.tar_entry_reader import ChunkedTarEntryReader
 from eatb.storage.checksum import check_transfer, ChecksumFile
 from eatb.utils.fileutils import fsize, FileBinaryDataChunks, to_safe_filename, \
-    get_immediate_subdirectories, copy_file_with_base_directory, list_files_in_dir
+    copy_file_with_base_directory, list_files_in_dir
 import json
 from subprocess import check_output
 
@@ -83,7 +83,7 @@ def make_storage_data_directory_path(identifier, config_path_storage):
 
 def files_identical(file1, file2):
     if not (os.path.exists(file1) and os.path.exists(file2)):
-                return False
+        return False
     checksum_source_file = ChecksumFile(file1).get('SHA-256')
     checksum_target_file = ChecksumFile(file2).get('SHA-256')
     logger.debug("f1: %s, f2: %s" % (file1, file2))
@@ -138,8 +138,7 @@ class DirectoryPairtreeStorage(PairtreeStorage):
         if os.path.exists(tar_file_path):
             logger.debug("Package file found at: %s" % tar_file_path)
             return tar_file_path
-        else:
-            raise ObjectNotFoundException("Package file not found")
+        raise ObjectNotFoundException("Package file not found")
 
     def get_object_item_stream(self, identifier, representation_label, entry, tar_file=None):
         """
@@ -233,7 +232,7 @@ class DirectoryPairtreeStorage(PairtreeStorage):
         target_dir = os.path.join(make_storage_data_directory_path(identifier, self.repository_storage_dir), version,
                                   to_safe_filename(identifier))
         changed = False
-        for path, dirs, files in os.walk(os.path.abspath(working_dir)):
+        for path, _, files in os.walk(os.path.abspath(working_dir)):
             sub_path = path.replace(working_dir, "").lstrip("/")
             for file in files:
                 # copy only packaged datasets, not the directories

--- a/eatb/storage/ipstate.py
+++ b/eatb/storage/ipstate.py
@@ -10,7 +10,7 @@ from eatb.xml.xmlutils import prettify
 from eatb.utils.datetime import current_timestamp
 
 
-class IpState(object):
+class IpState():
     """
     TaskExecutionXml class which represents an XML document to persist task execution parameters and results.
     The class can be initiated by parameters (static method from_parameters), by XML content string (static
@@ -38,7 +38,6 @@ class IpState(object):
         @rtype: TaskExecutionXml
         @return: TaskExecutionXml object
         """
-        doc_content = doc_content
         ted = Etree.fromstring(doc_content)
         return cls(doc_content, ted)
 
@@ -211,8 +210,7 @@ class IpState(object):
         lastchange_elm = self.ted.find('.//lastchange')
         if lastchange_elm is None:
             return ""
-        else:
-            return self.ted.find('.//lastchange').text
+        return self.ted.find('.//lastchange').text
 
     def set_lastchange(self, lastchange_value):
         """

--- a/eatb/storage/pairtreestorage.py
+++ b/eatb/storage/pairtreestorage.py
@@ -10,16 +10,14 @@ import logging
 from pairtree import PairtreeStorageFactory, ObjectNotFoundException, shutil
 from eatb.utils.reporters import default_reporter
 
-from eatb.storage.checksum import ChecksumFile, ChecksumAlgorithm, check_transfer
+from eatb.storage.checksum import check_transfer
 from eatb.utils.fileutils import fsize, to_safe_filename, rec_find_files, FileBinaryDataChunks
 from eatb.packaging.tar_entry_reader import ChunkedTarEntryReader
 
 logger = logging.getLogger(__name__)
 
 
-import os
 import os.path
-import ntpath
 import tarfile
 from itertools import groupby
 
@@ -44,7 +42,7 @@ def get_package_from_storage(storage, task_context_path, package_uuid, package_e
         check_transfer(parent_object_path, package_in_dip_work_dir)
 
 
-class PairtreeStorage(object):
+class PairtreeStorage():
     """
     Pairtree storage class allowing to build a filesystem hierarchy for holding objects that are located by mapping
     identifier strings to object directory (or folder) paths with two characters at a time.
@@ -89,8 +87,7 @@ class PairtreeStorage(object):
             target_file_path = os.path.join(target_data_version_asset_directory, archive_file)
             if not os.path.exists(src_file_path):
                 raise ValueError("Archive file does not exist: %s" % src_file_path)
-            else:
-                shutil.copy2(src_file_path, target_file_path)
+            shutil.copy2(src_file_path, target_file_path)
         progress_reporter(100)
         return next_version
 
@@ -199,7 +196,7 @@ class PairtreeStorage(object):
         tuples = []
         for repofile in files:
             if repofile.endswith(".tar"):
-                f, fname = os.path.split(repofile)
+                f, _ = os.path.split(repofile)
                 if f.startswith("pairtree_root"):
                     version = f[-5:] if f[-5:] != '' else '00001'
                     repoitem = (repofile, version)

--- a/eatb/utils/datetime.py
+++ b/eatb/utils/datetime.py
@@ -31,23 +31,11 @@ class LengthBasedDateFormat(object):
     def reformat(self, target_fmt='%Y-%m-%dT%H:%M:%SZ'):
         if not self.date_str:
             return "1970-01-01T00:00:00Z"
-        method_name = 'format_' + str(len(self.date_str))
-        method = getattr(self, method_name, lambda: "1970-01-01T00:00:00Z")
-        return method(target_fmt)
+        return self.format(target_fmt, len(self.date_str))
 
     def format(self, target_fmt, length=10):
         fmt = "%d.%m.%Y" if length == 10 else "%d%m%Y" if length == 6 else "%Y"
         return reformat_date_string(fmt, self.date_str, target_fmt)
-
-    def format_4(self, target_fmt):
-        return self.format(target_fmt, length=4)
-
-    def format_6(self, target_fmt):
-        return self.format(target_fmt, length=6)
-
-    def format_10(self, target_fmt):
-        return self.format(target_fmt, length=10)
-
 
 def reformat_date_string(origin_fmt, origin_dts, target_fmt):
     return datetime.strptime(origin_dts, origin_fmt).strftime(target_fmt)

--- a/eatb/utils/encrypt.py
+++ b/eatb/utils/encrypt.py
@@ -8,7 +8,7 @@ from eatb.cli.cli import CliCommand
 
 
 def gpg_encrypt_file_passphrase(file, passphrase):
-    return CliCommand.get("gpg_passphrase_encrypt_file", {'file': file, 'passphrase': passphrase})
+    return CliCommand.get_command("gpg_passphrase_encrypt_file", {'file': file, 'passphrase': passphrase})
 
 
 

--- a/eatb/utils/fileutils.py
+++ b/eatb/utils/fileutils.py
@@ -383,21 +383,6 @@ def fsize(file_path, wd=None):
     path = fp if wd is None else os.path.join(wd, fp)
     return int(os.path.getsize(path))
 
-
-def human_readable_size(size, decimal_places=1):
-    """
-    Get a fhuman readable string representation for a given file size in bytes (integer)
-    :param size: size (integer)
-    :param decimal_places: number of decimal places in the result string
-    :return: human readable string representation of the file size
-    """
-    for unit in ['B','KiB','MiB','GiB','TiB']:
-        if size < 1024.0:
-            break
-        size /= 1024.0
-    return f"{size:.{decimal_places}f} {unit}"
-
-
 def get_mime_type(path):
     """
     Get mime type of a file

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,6 @@
 import unittest
 import tarfile
 import sys
-from os import listdir
 
 IP_compressed_path = '/home/matteo/eARK/earkweb/earkresources/AIP-test/siardpackage/SIA_test_animals_2.tar'
 rules_path = './rules.xml'


### PR DESCRIPTION
- removed little used function parameter type checking;
- removed uncalled bytes formatting function with Python 3.6-> compatible string formatting;
- cut redundant LOCs;
- using annotations rather class methods rather than `staticmethod(method)`;
- removed redundant `elif`s and `else`s;
- removed unused import statements; and
- removed unnecessary `object` base class declarations.